### PR TITLE
Add method to retrieve user roles for a specific user in functional tests

### DIFF
--- a/gcl_iam/tests/functional/clients.py
+++ b/gcl_iam/tests/functional/clients.py
@@ -188,6 +188,13 @@ class GenesisCoreTestNoAuthRESTClient(common.RESTClientMixIn):
         )
         return None if result.status_code == 204 else result.json()
 
+    def get_user_roles(self, user_uuid):
+        return self.get(
+            self.build_resource_uri(
+                ["iam/users/", user_uuid, "actions/get_my_roles"]
+            ),
+        ).json()
+
     def create_role(self, name):
         return self.post(
             f"{self._endpoint}iam/roles/",


### PR DESCRIPTION


Introduce `get_user_roles` method to `GenesisCoreTestNoAuthRESTClient` for fetching assigned roles via the `/iam/users/{user_uuid}/actions/get_my_roles` endpoint. Returns parsed JSON response to simplify role verification in test scenarios.