### PR TITLE
Add endpoint property accessor for GenesisCoreTestNoAuthRESTClient

### DIFF
--- a/gcl_iam/tests/functional/clients.py
+++ b/gcl_iam/tests/functional/clients.py
@@ -121,6 +121,10 @@ class GenesisCoreTestNoAuthRESTClient(common.RESTClientMixIn):
         self._timeout = timeout
         self._client = bazooka.Client(default_timeout=timeout)
 
+    @property
+    def endpoint(self):
+        return self._endpoint
+
     def build_resource_uri(self, paths, init_uri=None):
         return self._build_resource_uri(paths, init_uri=init_uri)
 
@@ -195,10 +199,17 @@ class GenesisCoreTestNoAuthRESTClient(common.RESTClientMixIn):
             ),
         ).json()
 
-    def create_role(self, name):
+    def create_role(self, name, description="Functional test role", **kwargs):
+        body = kwargs.copy()
+        body.update(
+            {
+                "name": name,
+                "description": description,
+            }
+        )
         return self.post(
             f"{self._endpoint}iam/roles/",
-            json={"name": name, "description": "Functional test role"},
+            json=body,
         ).json()
 
     def create_or_get_role(self, name):


### PR DESCRIPTION
Exposes the `_endpoint` value through a read-only `endpoint` property, improving encapsulation and allowing external components to safely retrieve the API base URL.

**Enhance create_role method with dynamic parameters** Modified `create_role` to accept optional `description` and arbitrary keyword arguments:
- Maintains backward compatibility with existing test cases by preserving the default description
- Enables custom role configurations via `**kwargs` for advanced testing scenarios
- Improves code flexibility by constructing the request body from combined parameters
- Simplifies future extensions to role creation API calls without signature changes