### PR TITLE
Allow unannotated fileds for Izulu exceptions

### DIFF
--- a/gcl_iam/exceptions.py
+++ b/gcl_iam/exceptions.py
@@ -19,6 +19,7 @@ from izulu import root
 
 
 class GenesisCoreLibraryIamError(root.Error):
+    __toggles__ = root.Toggles.DEFAULT ^ root.Toggles.FORBID_UNANNOTATED_FIELDS
     __template__ = "Generic Genesis Core Library IAM Error"
 
 


### PR DESCRIPTION
The default behaviour of Izulu package was changend, it restricted unannotated fields. Enable original behaviour using special options.