### PR TITLE
Added email confirmation method to GenesisCoreTestNoAuthRESTClient

### DIFF
--- a/gcl_iam/tests/functional/clients.py
+++ b/gcl_iam/tests/functional/clients.py
@@ -158,6 +158,15 @@ class GenesisCoreTestNoAuthRESTClient(common.RESTClientMixIn):
             json=body,
         ).json()
 
+    def confirm_email(self, user_uuid, code=None):
+        body = {"code": code}
+        return self.post(
+            self.build_resource_uri(
+                ["iam/users", user_uuid, "actions/confirm_email/invoke"]
+            ),
+            json=body,
+        ).json()
+
     def list_users(self, **kwargs):
         params = kwargs.copy()
         return self.get(


### PR DESCRIPTION
Implemented a new `confirm_email` method in the test client to support email confirmation functionality during testing. The method:
- Takes `user_uuid` and optional `code` parameters
- Sends POST request to `/iam/users/{user_uuid}/actions/confirm_email/invoke` endpoint