### PR TITLE
Apply controller autovalues on policy updates

### DIFF
--- a/gcl_iam/api/controllers.py
+++ b/gcl_iam/api/controllers.py
@@ -108,6 +108,7 @@ class PolicyBasedController(
         if "project_id" in kwargs and self._ctx_project_id:
             self._force_project_id(kwargs["project_id"])
         dm = super(PolicyBasedController, self).get(uuid, **filters)
+        kwargs = self._apply_autovalues(kwargs)
         dm.update_dm(values=kwargs)
         dm.update()
         return dm
@@ -174,6 +175,7 @@ class PolicyBasedWithoutProjectController(
         self._enforce("update")
         dm = super().get(uuid)
 
+        kwargs = self._apply_autovalues(kwargs)
         dm.update_dm(values=kwargs)
         dm.update()
         return dm

--- a/gcl_iam/tests/unit/test_controllers.py
+++ b/gcl_iam/tests/unit/test_controllers.py
@@ -166,6 +166,54 @@ class TestPolicyBasedControllerMixin:
         assert kwargs == {"project_id": FAKE_PROJECT_ID}
 
 
+class TestPolicyBasedController:
+    def test_update_applies_autovalues(self, user_context):
+        pc = controllers.PolicyBasedController(request=mock.Mock())
+        pc._enforce_and_override_project_id_in_kwargs = mock.Mock()
+        pc._apply_autovalues = mock.Mock(return_value={"name": "server"})
+        dm = mock.Mock()
+        resource_id = uuid.uuid4()
+
+        with mock.patch.object(
+            controllers.controllers.BaseResourceController,
+            "get",
+            return_value=dm,
+        ) as get:
+            result = pc.update(resource_id, name="client")
+
+        pc._enforce_and_override_project_id_in_kwargs.assert_called_once_with(
+            "update", {}
+        )
+        get.assert_called_once_with(resource_id)
+        pc._apply_autovalues.assert_called_once_with({"name": "client"})
+        dm.update_dm.assert_called_once_with(values={"name": "server"})
+        dm.update.assert_called_once_with()
+        assert result is dm
+
+
+class TestPolicyBasedWithoutProjectController:
+    def test_update_applies_autovalues(self, user_context):
+        pc = controllers.PolicyBasedWithoutProjectController(request=mock.Mock())
+        pc._enforce = mock.Mock()
+        pc._apply_autovalues = mock.Mock(return_value={"name": "server"})
+        dm = mock.Mock()
+        resource_id = uuid.uuid4()
+
+        with mock.patch.object(
+            controllers.controllers.BaseResourceController,
+            "get",
+            return_value=dm,
+        ) as get:
+            result = pc.update(resource_id, name="client")
+
+        pc._enforce.assert_called_once_with("update")
+        get.assert_called_once_with(resource_id)
+        pc._apply_autovalues.assert_called_once_with({"name": "client"})
+        dm.update_dm.assert_called_once_with(values={"name": "server"})
+        dm.update.assert_called_once_with()
+        assert result is dm
+
+
 class TestPolicyBasedCheckOtpController:
     def test_check_otp_verified_true(self, otp_enabled_context):
         pc = controllers.PolicyBasedCheckOtpController(request=mock.Mock())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 dependencies = [
     "bazooka>=1.1.0,<2.0.0",  # Apache-2.0
-    "restalchemy>=15.1.2,<16.0.0",  # Apache-2.0
+    "restalchemy>=15.2.0,<16.0.0",  # Apache-2.0
     "izulu>=0.50.0,<1.0.0",  # MIT License
     "pyjwt>=2.9.0,<3.0.0",  # MIT License
     "cryptography>=45.0.5,<47.0.0",  # BSD-3 License

--- a/uv.lock
+++ b/uv.lock
@@ -988,7 +988,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0,<9.0.0" },
     { name = "pytest-timer", marker = "extra == 'test'", specifier = ">=1.0.0,<2.0.0" },
     { name = "pytest-xdist", extras = ["psutil"], marker = "extra == 'test'", specifier = ">=3.6.1,<4.0.0" },
-    { name = "restalchemy", specifier = ">=15.1.2,<16.0.0" },
+    { name = "restalchemy", specifier = ">=15.2.0,<16.0.0" },
     { name = "ruff", marker = "extra == 'ruff'" },
     { name = "shellcheck-py", marker = "extra == 'shellcheck'" },
     { name = "tox", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -2422,7 +2422,7 @@ wheels = [
 
 [[package]]
 name = "restalchemy"
-version = "15.1.2"
+version = "15.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "email-validator" },
@@ -2439,9 +2439,9 @@ dependencies = [
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "webob" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/cb/c43c63537ead1324c150308b6856c2579bf75fb166d2d5db003f6e38134b/restalchemy-15.1.2.tar.gz", hash = "sha256:17a1c83444b8a813ea60ed75b8e877075661d5d81cccb2e190964599a6af32bd", size = 438998, upload-time = "2026-06-15T14:17:33.735Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/d8/455316dd30d281651c99335949a15cebbb3812d573777bf2138ac3351976/restalchemy-15.2.0.tar.gz", hash = "sha256:d99c200998d4ed5deced2bc65a86382596d4240a86ed3e80d228a46d8321b93a", size = 442673, upload-time = "2026-06-24T11:35:03.366Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/db/abe78a331a7c81dae9503dcc8fa67d7b624262c77263007b45b45bd64b5c/restalchemy-15.1.2-py3-none-any.whl", hash = "sha256:063491dc07b90130f858638c891dfa79a3c122086511b56294dc8c9a5cd87bcf", size = 491048, upload-time = "2026-06-15T14:17:32.12Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d8/f90e222ae25f0e1b1e5cdc54013219e56f3df7da348e475c31c10c10f769/restalchemy-15.2.0-py3-none-any.whl", hash = "sha256:3c00f92f6399415072c7effe44abddc30fc5b936507b5b7e72320d6a4036d774", size = 495315, upload-time = "2026-06-24T11:35:01.607Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed

- Applied controller autovalues before manual policy-based update flows call update_dm.
- Bumped restalchemy dependency to 15.2.0 and refreshed uv.lock.
- Added unit coverage for both policy-based update implementations.

## Why

These controllers implement update manually instead of delegating to the base restalchemy update method, so they need to apply the new autovalues hook explicitly.

## Validation

- tox -e develop -- gcl_iam/tests/unit
- tox -e py312-functional